### PR TITLE
Publications section is grouped and sorted

### DIFF
--- a/css/gabecohn.css
+++ b/css/gabecohn.css
@@ -447,6 +447,10 @@ h1 .trail{
     margin-bottom: 25px;
 }
 
+.section-publications .authorHighlight{
+    font-weight: bold;
+}
+
 .section-publications .publications-date{
     font-size: 8pt;
     text-transform:uppercase;

--- a/index.html
+++ b/index.html
@@ -169,16 +169,6 @@
 
         <h1>Publications <span class="trail">// Gabe Cohn</span></h1>
 
-        <div class="subnav well">
-            <ul class="subnav">
-                <li><a href="#publications-0">Conference</a></li>
-                <li><a href="#publications-1">Journal and Magazine</a></li>
-                <li><a href="#publications-2">Workshop</a></li>
-                <li><a href="#publications-3">Other</a></li>
-                <li><a href="#publications-4">Technical Reports</a></li>
-            </ul>
-        </div>
-
         <div class="publications-parent">
             <!-- Filled by content from json doc -->
         </div>

--- a/js/gabecohn.js
+++ b/js/gabecohn.js
@@ -28,7 +28,7 @@ $(function () {
 
     renderProjects(projectsJSON);
 
-    renderPublications(publicationsJSON);
+    renderPublications(publicationTypesJSON, publicationsJSON);
 
     renderTalks(talksJSON);
 
@@ -139,26 +139,36 @@ var handleAnchor = function(anchor) {
 
 var addIconsToLinks = function(links) {
     if (links && links.length && links.length > 0) {
-        for (var l = 0; l < links.length; l += 1) {
-            if (links[l].type) {
-                switch(links[l].type) {
-                    case "dl": links[l].icon = "book"; break;
-                    case "doc": links[l].icon = "file"; break;
-                    case "link": links[l].icon = "link"; break;
-                    case "proj": links[l].icon = "tag"; break;
-                    case "pub": links[l].icon = "file"; break;
-                    case "slides": links[l].icon = "file"; break;
-                    case "star": links[l].icon = "star-empty"; break;
-                    case "talk": links[l].icon = "film"; break;
-                    case "video": links[l].icon = "film"; break;
-                    case "web": links[l].icon = "globe"; break;
-                    default: links[l].icon = "file";
+        for (var i = 0; i < links.length; i += 1) {
+            if (links[i].type) {
+                switch(links[i].type) {
+                    case "dl": links[i].icon = "book"; break;
+                    case "doc": links[i].icon = "file"; break;
+                    case "link": links[i].icon = "link"; break;
+                    case "proj": links[i].icon = "tag"; break;
+                    case "pub": links[i].icon = "file"; break;
+                    case "slides": links[i].icon = "file"; break;
+                    case "star": links[i].icon = "star-empty"; break;
+                    case "talk": links[i].icon = "film"; break;
+                    case "video": links[i].icon = "film"; break;
+                    case "web": links[i].icon = "globe"; break;
+                    default: links[i].icon = "file";
                 }
             }
         }
     }
     return links;
 }
+
+// Helper method to find an element within an array which has an attribute of a specified name and value
+var getArrayElementWithAttribute = function(array, nameValue) {
+    for (var i = 0; i < array.length; i += 1) {
+        if (array[i] && array[i][nameValue.name] && array[i][nameValue.name] === nameValue.value) {
+            return array[i];
+        }
+    }
+    return undefined;
+};
 
 var renderProjects = function(jsonData) {
     var $parent = $(".projects-parent"),
@@ -307,20 +317,30 @@ var renderProjects = function(jsonData) {
     $parent.append(renderedHTML);
 };
 
-var renderPublications = function(jsonData) {
+var renderPublications = function(typesJsonData, jsonData) {
     var $parent = $(".publications-parent"),
         htmlTemplate,
+        htmlNavTemplate,
         htmlGroupStartTemplate,
         htmlGroupEndTemplate,
         publication,
+        publicationType,
         publicationGroup,
-        groupId,
+        publicationGroups = [],
         publicationId,
         renderedHTML;
 
+    htmlNavTemplate  = '<div class="subnav well">';
+    htmlNavTemplate += '    <ul class="subnav">';
+    htmlNavTemplate += '        {{#types}}';
+    htmlNavTemplate += '            <li><a href="#publications-{{ name }}">{{ displayName }}</a></li>';
+    htmlNavTemplate += '        {{/types}}';
+    htmlNavTemplate += '    </ul>';
+    htmlNavTemplate += '</div>';
+
     htmlGroupStartTemplate = '' +
         '<div class="publications-anchor">' +
-        '    <a name="publications-{{ id }}"></a>' +
+        '    <a name="publications-{{ type }}"></a>' +
         '</div>' +
         '<div class="panel panel-default">' +
         '    <div class="panel-heading">' +
@@ -337,12 +357,12 @@ var renderPublications = function(jsonData) {
     htmlTemplate = '' +
         '        <div class="publication row">' +
         '            <div class="index col-md-1" id="publication-{{ index }}">{{ index }}</div>' +
-        '            <div class="col-md-2"><a href="{{ paperUrl }}">' +
-        '                <img class="img-thumbnail" src="{{ thumbUrl }}" alt=""/></a>' +
+        '            <div class="col-md-2"><a href="{{ link }}">' +
+        '                <img class="img-thumbnail" src="img/publications/{{ id }}.jpg" alt=""/></a>' +
         '            </div>' +
         '            <div class="col-md-6">' +
         '                <div class="publications-date">{{{ date }}}</div>' +
-        '                {{{ authors }}} <a href="{{ paperUrl }}"><strong>{{{ title }}}</strong></a>. {{{ context }}}' +
+        '                {{{ authors }}} <a href="{{ link }}"><strong>{{{ title }}}</strong></a>. {{{ publication }}}' +
         '                {{#acceptanceRate}}' +
         '                <div class="publications-acceptance">' +
         '                    [Acceptance Rate: {{ acceptanceRate }}]' +
@@ -353,21 +373,9 @@ var renderPublications = function(jsonData) {
         '                {{/awards}}' +
         '            </div>' +
         '            <div class="col-md-3">' +
-        '                {{#paperUrl}}' +
-        '                <a href="{{ paperUrl }}"><div class="badge-publication"><span class="label label-info"><span class="glyphicon glyphicon-file"></span> paper</span></div></a>' +
-        '                {{/paperUrl}}' +
-        '                {{#videoUrl}}' +
-        '                <a href="{{ videoUrl }}"><div class="badge-video"><span class="label label-info"><span class="glyphicon glyphicon-film"></span> video</span></div></a>' +
-        '                {{/videoUrl}}' +
-        '                {{#talkVideoUrl}}' +
-        '                <a href="{{ talkVideoUrl }}"><div class="badge-video"><span class="label label-info"><span class="glyphicon glyphicon-film"></span> talk video</span></div></a>' +
-        '                {{/talkVideoUrl}}' +
-        '                {{#dlUrl}}' +
-        '                <a href="{{ dlUrl }}"><div class="badge-publication"><span class="label label-info"><span class="glyphicon glyphicon-book"></span> Digital Library</span></div></a>' +
-        '                {{/dlUrl}}' +
-        '                {{#project}}' +
-        '                <a href="#{{ project }}"><div class="badge-publication"><span class="label label-info"><span class="glyphicon glyphicon-tag"></span> project info</span></div></a>' +
-        '                {{/project}}' +
+        '                {{#links}}' +
+        '                    <a href="{{ url }}"><div class="badge-publication"><span class="label label-info"><span class="glyphicon glyphicon-{{ icon }}"></span> {{ title }}</span></div></a>' +
+        '                {{/links}}' +
         '            </div>' +
         '        </div>';
 
@@ -376,28 +384,85 @@ var renderPublications = function(jsonData) {
         return;
     }
 
+    // Group publications by publication.type
+    for (var i = 0; i < jsonData.length; i += 1) {
+        publicationGroup = getArrayElementWithAttribute(publicationGroups, {"name":"type", "value":jsonData[i].type});
+        if (publicationGroup) {
+            publicationGroup["rows"].push(jsonData[i]);
+        } else {
+            publicationGroup = {"type":jsonData[i].type, "rows":[jsonData[i]]};
+            publicationGroups.push(publicationGroup);
+        }
+    }
+
+    // Sort types by their sortOrder attribute
+    typesJsonData.sort(function(a, b){
+        if (a.sortOrder > b.sortOrder) {
+            return 1;
+        }
+        if (a.sortOrder < b.sortOrder) {
+            return -1;
+        }
+        return 0;
+    });
+
+    // Sort groups by the sort order defined in types json data
+    publicationGroups.sort(function(a, b){
+        var aType = getArrayElementWithAttribute(typesJsonData, {"name":"name", "value": a.type}),
+            bType = getArrayElementWithAttribute(typesJsonData, {"name":"name", "value": b.type});
+
+        if (!aType) {
+            console.log("No publication type found with name: " + a.type);
+            return 1;
+        }
+        if (!bType) {
+            console.log("No publication type found with name: " + b.type);
+            return -1;
+        }
+
+        if (aType.sortOrder > bType.sortOrder) {
+            return 1;
+        }
+        if (aType.sortOrder > bType.sortOrder) {
+            return -1;
+        }
+        return 0;
+    });
+
+
+    // Render HTML from templates
     renderedHTML = '';
-//    for(groupId = 0; groupId < jsonData.length; groupId++) { // TODO: GRUMMER - Group publications by publication.type
-//        publicationGroup = jsonData[groupId];
-//
-//        publicationGroup["id"] = groupId;
-//
-//        renderedHTML += Mustache.render(htmlGroupStartTemplate, publicationGroup);
-//
-//        for(publicationId = 0; publicationId < publicationGroup["publications"].length; publicationId++) {
-//            publication = publicationGroup["publications"][publicationId];
-//
-//            if (publication.links) {
-//                publication.links = addIconsToLinks(publication.links);
-//            }
-//
-//            renderedHTML += Mustache.render(htmlTemplate, publication);
-//        }
-//
-//        renderedHTML += Mustache.render(htmlGroupEndTemplate, publicationGroup);
-//    }
-//
-//    $parent.append(renderedHTML);
+
+    renderedHTML += Mustache.render(htmlNavTemplate, {"types":typesJsonData});
+
+    for(var groupId = 0; groupId < publicationGroups.length; groupId += 1) {
+        publicationGroup = publicationGroups[groupId];
+        publicationType = getArrayElementWithAttribute(typesJsonData, {"name":"name", "value": publicationGroup.type});
+
+        publicationGroup["id"] = groupId;
+        if (publicationType) {
+            publicationGroup["title"] = publicationType.displayName;
+        } else {
+            console.log("No publication type found with name: " + publicationGroup.type);
+            publicationGroup["title"] = publicationGroup.type;
+        }
+
+        renderedHTML += Mustache.render(htmlGroupStartTemplate, publicationGroup);
+
+        for(publicationId = 0; publicationId < publicationGroup["rows"].length; publicationId++) {
+            publication = publicationGroup["rows"][publicationId];
+
+            if (publication.links) {
+                publication.links = addIconsToLinks(publication.links);
+            }
+
+            renderedHTML += Mustache.render(htmlTemplate, publication);
+        }
+
+        renderedHTML += Mustache.render(htmlGroupEndTemplate, publicationGroup);
+    }
+
+    $parent.append(renderedHTML);
 };
 
 var renderTalks = function(jsonData) {

--- a/json/publications.js
+++ b/json/publications.js
@@ -1,30 +1,64 @@
 /* Publications JSON structure
  The publication should be grouped by the "type" tag, in the following order, with the following group titles:
- "conference" - "Conference Publications"
- "journal" - "Journal and Magazine Publications"
- "workshop" - "Workshop Publications"
- "thesis" - "Thesis"
- "other" - "Other Articles"
- "report" - "Technical Reports"
+     "conference" - "Conference Publications"
+     "journal" - "Journal and Magazine Publications"
+     "workshop" - "Workshop Publications"
+     "thesis" - "Thesis"
+     "other" - "Other Articles"
+     "report" - "Technical Reports"
  Within each group, the publications should appear in the order of the objects in the JSON structure.
  Each publication object contains the following:
- id - string, for referencing this pub in other JSON objects and the id of the <div>
- the URL for the thumbnail will be "img/publications/<id>.jpg" where <id> is replaced with the id
- always starts with pub_
- index - string, CV reference index that is displayed on the page
- type - string, determines which category the publication is displayed in, must be from the list of types shown at the top of this comment block
- link - string or NULL, jump to this URL if the thumbnail or title is clicked. If NULL, then the thumbnail and title are not clickable.
- year - string, year of publication to display
- authors - string (with HTML), list of authors as displayed in citation. <div class="authorHighlight"> should be around my name.
- title - string, title of paper (clickable if link is not NULL)
- publication - string (with HTML), all text in the citation that appears after the title
- acceptance - string or NULL, acceptance rate message to display. If NULL, no acceptance rate is displayed.
- links - an array of the following object. Links are to appear in the order listed
- title - string, display text
- type - string, one of the following {doc, slides, video, dl, pub, talk, proj, web}. The type determines the icon to show
- url - string, URL of the link (use #proj_id if a project link)
- relatedProjects - an array of project id (proj_id) strings. This allows the projects section of the page to list publication for each project.
+     id - string, for referencing this pub in other JSON objects and the id of the <div>
+     the URL for the thumbnail will be "img/publications/<id>.jpg" where <id> is replaced with the id
+     always starts with pub_
+     index - string, CV reference index that is displayed on the page
+     type - string, determines which category the publication is displayed in, must be from the list of types shown at the top of this comment block
+     link - string or NULL, jump to this URL if the thumbnail or title is clicked. If NULL, then the thumbnail and title are not clickable.
+     year - string, year of publication to display // TODO - GRUMMER
+     authors - string (with HTML), list of authors as displayed in citation. <div class="authorHighlight"> should be around my name.
+     title - string, title of paper (clickable if link is not NULL)
+     publication - string (with HTML), all text in the citation that appears after the title
+     acceptance - string or NULL, acceptance rate message to display. If NULL, no acceptance rate is displayed.
+     links - an array of the following object. Links are to appear in the order listed
+         title - string, display text
+         type - string, one of the following {doc, slides, video, dl, pub, talk, proj, web}. The type determines the icon to show
+         url - string, URL of the link (use #proj_id if a project link)
+     relatedProjects - an array of project id (proj_id) strings. This allows the projects section of the page to list publication for each project. // TODO - GRUMMER
  */
+
+var publicationTypesJSON = [
+    {
+        "name": "conference",
+        "displayName": "Conference Publications",
+        "sortOrder": 10
+    },
+    {
+        "name": "journal",
+        "displayName": "Journal and Magazine Publications",
+        "sortOrder": 20
+    },
+    {
+        "name": "workshop",
+        "displayName": "Workshop Publications",
+        "sortOrder": 30
+    },
+    {
+        "name": "thesis",
+        "displayName": "Thesis",
+        "sortOrder": 40
+    },
+    {
+        "name": "other",
+        "displayName": "Other Articles",
+        "sortOrder": 50
+    },
+    {
+        "name": "report",
+        "displayName": "Technical Reports",
+        "sortOrder": 60
+    }
+];
+
 var publicationsJSON = [
     {
         "id": "pub_C9",
@@ -32,7 +66,7 @@ var publicationsJSON = [
         "type": "conference",
         "link": "pdf/Chen_uTouch_chi13.pdf",
         "year": "2013",
-        "authors": "Chen, K., <div class=\"authorHighlight\">Cohn, G.</div>, Gupta, S., Patel, S.N.",
+        "authors": "Chen, K., <span class=\"authorHighlight\">Cohn, G.</span>, Gupta, S., Patel, S.N.",
         "title": "uTouch: Sensing Touch Gestures on Unmodified LCDs",
         "publication": "In the <em>Proceedings of CHI 2013</em> (April 27 - May 2, Paris, France), ACM, New York, 2013, pp. 2051-2054.",
         "acceptance": "20% (392/1963)",
@@ -66,7 +100,7 @@ var publicationsJSON = [
         "type": "conference",
         "link": "pdf/Cohn_SEFS_ubicomp12.pdf",
         "year": "2012",
-        "authors": "<div class=\"authorHighlight\">Cohn, G.</div>, Gupta, S., Lee, T., Morris, D., Smith, J.R., Reynolds, M.S., Tan, D.S., Patel, S.N.",
+        "authors": "<span class=\"authorHighlight\">Cohn, G.</span>, Gupta, S., Lee, T., Morris, D., Smith, J.R., Reynolds, M.S., Tan, D.S., Patel, S.N.",
         "title": "An Ultra-Low-Power Human Body Motion Sensor Using Static Electric Field Sensing",
         "publication": "In the <em>Proceedings of Ubicomp 2012</em> (Sept. 5-8, Pittsburgh, PA), ACM, New York, 2012, pp. 99-102.",
         "acceptance": "19% (58/301)",
@@ -100,7 +134,7 @@ var publicationsJSON = [
         "type": "conference",
         "link": "pdf/Cohn_Humantenna_chi12.pdf",
         "year": "2012",
-        "authors": "<div class=\"authorHighlight\">Cohn, G.</div>, Morris, D., Patel, S.N., Tan, D.S.",
+        "authors": "<span class=\"authorHighlight\">Cohn, G.</span>, Morris, D., Patel, S.N., Tan, D.S.",
         "title": "Humantenna: Using the Body as an Antenna for Real-Time Whole-Body Interaction",
         "publication": "In the <em>Proceedings of CHI 2012</em> (May 5-10, Austin, TX), ACM, New York, 2012, pp. 1901-1910.",
         "acceptance": "23% (370/1577)",
@@ -139,7 +173,7 @@ var publicationsJSON = [
         "type": "conference",
         "link": "pdf/Cohn_NoiseCommand_chi11.pdf",
         "year": "2011",
-        "authors": "<div class=\"authorHighlight\">Cohn, G.</div>, Morris, D., Patel, S.N., Tan, D.S.",
+        "authors": "<span class=\"authorHighlight\">Cohn, G.</span>, Morris, D., Patel, S.N., Tan, D.S.",
         "title": "Your Noise is My Command: Sensing Gestures Using the Body as an Antenna",
         "publication": "In the <em>Proceedings of CHI 2011</em> (May 7-12, Vancouver, Canada), ACM, New York, 2011, pp. 791-800.",
         "acceptance": "26% (400/1540)",
@@ -173,7 +207,7 @@ var publicationsJSON = [
         "type": "conference",
         "link": "pdf/Badshah_InGen_chi11.pdf",
         "year": "2011",
-        "authors": "Badshah, A., Gupta, S., <div class=\"authorHighlight\">Cohn, G.</div>, Villar, N., Hodges, S., Patel, S.N.",
+        "authors": "Badshah, A., Gupta, S., <span class=\"authorHighlight\">Cohn, G.</span>, Villar, N., Hodges, S., Patel, S.N.",
         "title": "Interactive Generator: A Self-Powered Haptic Feedback Device",
         "publication": "In the <em>Proceedings of CHI 2011</em> (May 7-12, Vancouver, Canada), ACM, New York, 2011, pp. 2051-2054.",
         "acceptance": "26% (400/1540)",
@@ -202,7 +236,7 @@ var publicationsJSON = [
         "type": "conference",
         "link": "pdf/Larson_HeatWave_chi11.pdf",
         "year": "2011",
-        "authors": "Larson, E., <div class=\"authorHighlight\">Cohn, G.</div>, Gupta, S., Ren, X., Harrison, B., Fox, D., Patel, S.N.",
+        "authors": "Larson, E., <span class=\"authorHighlight\">Cohn, G.</span>, Gupta, S., Ren, X., Harrison, B., Fox, D., Patel, S.N.",
         "title": "HeatWave: Thermal Imaging for Surface User Interaction",
         "publication": "In the <em>Proceedings of CHI 2011</em> (May 7-12, Vancouver, Canada), ACM, New York, 2011, pp. 2565-2574.",
         "acceptance": "26% (400/1540)",
@@ -231,7 +265,7 @@ var publicationsJSON = [
         "type": "conference",
         "link": "pdf/Campbell_WATTR_ubicomp10.pdf",
         "year": "2010",
-        "authors": "Campbell, T., Larson, E., <div class=\"authorHighlight\">Cohn, G.</div>, Froehlich, J., ALcaide, R., Patel, S.N.",
+        "authors": "Campbell, T., Larson, E., <span class=\"authorHighlight\">Cohn, G.</span>, Froehlich, J., ALcaide, R., Patel, S.N.",
         "title": "WATTR: A Method for Self-Powered Wireless Sensing of Water Activity in the Home",
         "publication": "In the <em>Proceedings of UbiComp 2010</em> (Sept. 26-29, Copenhagen, Denmark), ACM, New York, 2010, pp. 169-172.",
         "acceptance": "19% (39/202)",
@@ -260,7 +294,7 @@ var publicationsJSON = [
         "type": "conference",
         "link": "pdf/Cohn_SNUPI_ubicomp10.pdf",
         "year": "2010",
-        "authors": "<div class=\"authorHighlight\">Cohn, G.</div>, Stuntebeck, E., Pandey, J., Otis, B., Abowd, G.D., Patel, S.N.",
+        "authors": "<span class=\"authorHighlight\">Cohn, G.</span>, Stuntebeck, E., Pandey, J., Otis, B., Abowd, G.D., Patel, S.N.",
         "title": "SNUPI: Sensor Nodes Utilizing Powerline Infrastructure",
         "publication": "In the <em>Proceedings of UbiComp 2010</em> (Sept. 26-29, Copenhagen, Denmark), ACM, New York, 2010, pp. 159-168.",
         "acceptance": "19% (39/202)",
@@ -289,7 +323,7 @@ var publicationsJSON = [
         "type": "conference",
         "link": "pdf/Cohn_GasSense_pervasive10.pdf",
         "year": "2010",
-        "authors": "<div class=\"authorHighlight\">Cohn, G.</div>, Gupta, S., Froehlich, J., Larson, E., and Patel, S.N.",
+        "authors": "<span class=\"authorHighlight\">Cohn, G.</span>, Gupta, S., Froehlich, J., Larson, E., and Patel, S.N.",
         "title": "GasSense: Appliance-Level, Single-Point Sensing of Gas Activity in the Home",
         "publication": "In the <em>Proceedings of Pervasive 2010</em> (May 17-20, Helsinki, Finland), Springer-Verlag, Heidelberg, 2010, pp. 265-282.",
         "acceptance": "16% (26/161)",
@@ -318,7 +352,7 @@ var publicationsJSON = [
         "type": "journal",
         "link": "pdf/Froehlich_DisagEnergy_IEEEpervasive11.pdf",
         "year": "2011",
-        "authors": "Froehlich, J., Larson, E., Gupta, S., <div class=\"authorHighlight\">Cohn, G.</div>, Reynolds, M.S., Patel, S.N.",
+        "authors": "Froehlich, J., Larson, E., Gupta, S., <span class=\"authorHighlight\">Cohn, G.</span>, Reynolds, M.S., Patel, S.N.",
         "title": "Disaggregated End-Use Energy for the Smart Grid",
         "publication": "<em>IEEE Pervasive Computing, Special Issue on Smart Energy Systems</em>, 10(1), Jan-Mar 2011, pp. 28-39.",
         "acceptance": null,
@@ -347,7 +381,7 @@ var publicationsJSON = [
         "type": "workshop",
         "link": "pdf/Levin_ElectionFraud_EVTWOTE09.pdf",
         "year": "2009",
-        "authors": "Levin, I., <div class=\"authorHighlight\">Cohn, G.A.</div>, Ordeshook, P.C., Alvarez, R.M.",
+        "authors": "Levin, I., <span class=\"authorHighlight\">Cohn, G.A.</span>, Ordeshook, P.C., Alvarez, R.M.",
         "title": "Detecting Voter Fraud in an Electronic Voting Context: An Analysis of the Unlimited Reelection Vote in Venezuela",
         "publication": "In the <em>Proceedings of 2009 Electronic Voting Technology Workshop/Workshop on Trustworthy Elections (EVT/WOTE '09)</em> (Aug. 10-11, Montreal, Canada), USENIX, 2009.",
         "acceptance": null,
@@ -371,7 +405,7 @@ var publicationsJSON = [
         "type": "thesis",
         "link": null,
         "year": "2014",
-        "authors": "<div class=\"authorHighlight\">Cohn, G.A.</div>",
+        "authors": "<span class=\"authorHighlight\">Cohn, G.A.</span>",
         "title": "SNUPI: Sensor Network Utilizing Powerline Infrastructure",
         "publication": "<em>University of Washington Doctoral Dissertation</em>, 2014.",
         "acceptance": null,
@@ -390,7 +424,7 @@ var publicationsJSON = [
         "type": "other",
         "link": "pdf/Cohn_Humantenna_EEK12.pdf",
         "year": "2012",
-        "authors": "<div class=\"authorHighlight\">Cohn, G.</div>, Morris, D., Patel, S.N., Tan, D.S.",
+        "authors": "<span class=\"authorHighlight\">Cohn, G.</span>, Morris, D., Patel, S.N., Tan, D.S.",
         "title": "Humantenna: Using the Body as an Antenna for Real-Time Whole- Body Interaction",
         "publication": "<em>University of Washington Electrical Engineering Kaleidoscope (EEK) Magazine</em>, 2012, p. 7.",
         "acceptance": null,
@@ -414,7 +448,7 @@ var publicationsJSON = [
         "type": "report",
         "link": "pdf/Cohn_CADFeeds_07.pdf",
         "year": "2007",
-        "authors": "<div class=\"authorHighlight\">Cohn, G.A.</div>",
+        "authors": "<span class=\"authorHighlight\">Cohn, G.A.</span>",
         "title": "Computer Modeling of Wideband Tapered-Slot Microwave Antenna Feeds",
         "publication": "<em>Caltech RF and Microwave Group</em>, 2007.",
         "acceptance": null,
@@ -438,7 +472,7 @@ var publicationsJSON = [
         "type": "report",
         "link": "pdf/Cohn_MeteorInterferometry_06.pdf",
         "year": "2006",
-        "authors": "<div class=\"authorHighlight\">Cohn, G.A.</div>, Sahr, J.D.",
+        "authors": "<span class=\"authorHighlight\">Cohn, G.A.</span>, Sahr, J.D.",
         "title": "Meteor radar interferometry using NEC antenna array simulations",
         "publication": "<em>University of Washington Radar Remote Sensing Laboratory</em>, 2006.",
         "acceptance": null,
@@ -462,7 +496,7 @@ var publicationsJSON = [
         "type": "report",
         "link": "pdf/Lind_ISISFirstLight_06.pdf",
         "year": "2006",
-        "authors": "Lind F., Berkowitz, Z., Morabito, A., Vertatschitsch, L., <div class=\"authorHighlight\">Cohn, G.</div>, Nguyen, K., Sahr, J.",
+        "authors": "Lind F., Berkowitz, Z., Morabito, A., Vertatschitsch, L., <span class=\"authorHighlight\">Cohn, G.</span>, Nguyen, K., Sahr, J.",
         "title": "RRSL Milestone: First E Region Irregularities on ISIS",
         "publication": "<em>University of Washington Radar Remote Sensing Laboratory</em>, 2006.",
         "acceptance": null,


### PR DESCRIPTION
Publications are grouped and sorted by "type" now, with display names and sort order defined in the new "publicationTypesJSON" data in publications.json. I still have a few minor pieces to cleanup in Publications and then I'll be moving on to Projects.